### PR TITLE
fix: fixed github template to be checkboxes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,19 @@
 ### Description
+
 <!--- Please add the card link from trello within the description as well. THANKS!! !--->
 
-### Types of chnages
-[] Feature
-[] Bug fix
-[] Chore
-[] Other... <!--- describe !--->
+### Types of change
+
+- [ ] Feature
+- [ ] Bug fix
+- [ ] Chore
+- [ ] Other... added dependencies
 
 ### ScreenShots
+
 <!--- if any !--->
 
 ### Testing
-[] Manually tested
-[] ran `yarn dev` and `yarn test`
+
+- [ ] Manually tested
+- [ ]ran `yarn dev` and `yarn test`


### PR DESCRIPTION
### Description
<!--- Please add the card link from trello within the description as well. THANKS!! !--->
fixed github template checkboxes

Currently, template is showing [] instead of 
- [ ] Feature

### Types of change
- [ ] Feature
- [ ] Bug fix
- [ ] Chore
- [x] Other... added dependencies 

### ScreenShots
<!--- if any !--->

### Testing
[] Manually tested
[] ran `yarn dev` and `yarn test`
